### PR TITLE
Changes getOnlineStatus() ping to use awk on 'X received packets'

### DIFF
--- a/_official/lico-update.sh
+++ b/_official/lico-update.sh
@@ -672,7 +672,7 @@ getUptime() {
 
 getOnlineStatus() {
     if [ "${OS}" = "Linux" ]; then
-        pingstatus=$( ${PING} -q -c 1 linuxcounter.net 2>&1 | ${GREP} -i packet | ${CUT} -d " " -f 1 )
+        pingstatus=$( ${PING} -q -c 1 linuxcounter.net 2>&1 | ${GREP} -i packet | ${AWK} '{print $4}' )
         [ "${pingstatus}" = "" ] && echo "0"
         [ "${pingstatus}" -gt 0 ] && echo "1"
     fi


### PR DESCRIPTION
  Prior to this it was using 'cut' when awk is almost certainly better
for this job, but more importantly it was going to not see a difference
between:

	1 packets transmitted, 1 received, 0% packet loss, time 0ms
	1 packets transmitted, 0 received, 100% packet loss, time 0ms

as it was looking at the *first* cut field, i.e. the '1' in '1 packets
transmitted'.  This awk change now has it look at the 4th field which is
the X in "X received".